### PR TITLE
Globus & Gantry monitor services + API endpoints

### DIFF
--- a/scripts/gantrymonitor/Dockerfile
+++ b/scripts/gantrymonitor/Dockerfile
@@ -8,6 +8,7 @@ RUN groupadd -g 1006 cache_access \
     && pip install flask-restful \
     && pip install requests \
     && pip install globusonline-transfer-api-client \
+    && pip install logstash \
     && mkdir /home/gantry \
     && chown -R data-mover /home/gantry \
     && chown -R data-mover /var/log

--- a/scripts/gantrymonitor/Dockerfile
+++ b/scripts/gantrymonitor/Dockerfile
@@ -8,7 +8,6 @@ RUN groupadd -g 1006 cache_access \
     && pip install flask-restful \
     && pip install requests \
     && pip install globusonline-transfer-api-client \
-    && pip install python-logstash \
     && mkdir /home/gantry \
     && chown -R data-mover /home/gantry \
     && chown -R data-mover /var/log

--- a/scripts/gantrymonitor/Dockerfile
+++ b/scripts/gantrymonitor/Dockerfile
@@ -14,6 +14,7 @@ RUN groupadd -g 1006 cache_access \
 
 COPY gantry_monitor_service.py /home/gantry/gantry_monitor_service.py
 COPY config_default.json /home/gantry/config_default.json
+COPY config_logging.json /home/gantry/config_logging.json
 
 ENV MONITOR_API_PORT 5455
 USER data-mover

--- a/scripts/gantrymonitor/Dockerfile
+++ b/scripts/gantrymonitor/Dockerfile
@@ -8,7 +8,7 @@ RUN groupadd -g 1006 cache_access \
     && pip install flask-restful \
     && pip install requests \
     && pip install globusonline-transfer-api-client \
-    && pip install logstash \
+    && pip install python-logstash \
     && mkdir /home/gantry \
     && chown -R data-mover /home/gantry \
     && chown -R data-mover /var/log

--- a/scripts/gantrymonitor/Dockerfile
+++ b/scripts/gantrymonitor/Dockerfile
@@ -7,6 +7,7 @@ RUN groupadd -g 1006 cache_access \
     && apt-get -y install curl python python-dev python-pip \
     && pip install flask-restful \
     && pip install requests \
+    && pip install python-logstash \
     && pip install globusonline-transfer-api-client \
     && mkdir /home/gantry \
     && chown -R data-mover /home/gantry \

--- a/scripts/gantrymonitor/config_default.json
+++ b/scripts/gantrymonitor/config_default.json
@@ -19,6 +19,7 @@
 
   "globus": {
     "source_path": "/gantry_data/LemnaTec",
+    "delete_path": "/gantry_data/LemnaTec/ToDelete",
     "destination_path": "/~/globus",
     "source_endpoint_id": "",
     "destination_endpoint_id": "",

--- a/scripts/gantrymonitor/config_default.json
+++ b/scripts/gantrymonitor/config_default.json
@@ -10,9 +10,9 @@
     "incoming_files_path": "/home/gantry/sensors",
     "deletion_queue": "/home/gantry/delete/sensors",
     "ftp_log_path": "/var/log",
-    "file_check_frequency_secs": 120,
-    "max_pending_files": 25000,
-    "globus_transfer_frequency_secs": 180,
+    "file_check_frequency_secs": 60,
+    "max_pending_files": 40000,
+    "globus_transfer_frequency_secs": 90,
     "file_age_monitor_paths": [],
     "min_file_age_for_transfer_mins": 15
   },

--- a/scripts/gantrymonitor/config_logging.json
+++ b/scripts/gantrymonitor/config_logging.json
@@ -41,6 +41,6 @@
 
   "root": {
     "level": "INFO",
-    "handlers": ["console", "logstash"]
+    "handlers": []
   }
 }

--- a/scripts/gantrymonitor/config_logging.json
+++ b/scripts/gantrymonitor/config_logging.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+
+  "formatters": {
+    "default": {
+      "format": "%(asctime)-15s %(levelname)-7s : %(name)s - %(message)s"
+    }
+  },
+
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "formatter": "default",
+      "level": "DEBUG",
+      "stream": "ext://sys.stdout"
+    },
+    "file": {
+      "class": "logging.handlers.RotatingFileHandler",
+      "formatter": "default",
+      "level": "INFO",
+      "filename": "ouput.log",
+      "maxBytes": 10485760,
+      "backupCount": 10,
+      "encoding": "utf8"
+    },
+    "logstash": {
+      "class": "logstash.TCPLogstashHandler",
+      "level": "INFO",
+      "host": "logger.ncsa.illinois.edu",
+      "port": 5000,
+      "message_type": "gantry",
+      "version": 1
+    }
+  },
+
+  "loggers": {
+    "gantry": {
+      "level": "DEBUG",
+      "handlers": ["console", "logstash", "file"]
+    }
+  },
+
+  "root": {
+    "level": "INFO",
+    "handlers": ["console", "logstash"]
+  }
+}

--- a/scripts/gantrymonitor/config_logging.json
+++ b/scripts/gantrymonitor/config_logging.json
@@ -18,9 +18,8 @@
       "class": "logging.handlers.RotatingFileHandler",
       "formatter": "default",
       "level": "DEBUG",
-      "filename": "ouput.log",
+      "filename": "gantry.log",
       "maxBytes": 10485760,
-      "backupCount": 10,
       "encoding": "utf8"
     },
     "logstash": {

--- a/scripts/gantrymonitor/config_logging.json
+++ b/scripts/gantrymonitor/config_logging.json
@@ -17,7 +17,7 @@
     "file": {
       "class": "logging.handlers.RotatingFileHandler",
       "formatter": "default",
-      "level": "INFO",
+      "level": "DEBUG",
       "filename": "ouput.log",
       "maxBytes": 10485760,
       "backupCount": 10,

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -848,7 +848,7 @@ if __name__ == '__main__':
         print("...no custom configuration file found. using default values")
 
     # Initialize logger handlers
-    with open(os.join(rootPath,"config_logging.json"), 'r') as f:
+    with open(os.path.join(rootPath,"config_logging.json"), 'r') as f:
         log_config = json.load(f)
         log_config['handlers']['file']['filename'] = config["log_path"]
         logging.config.dictConfig(log_config)

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -30,8 +30,8 @@ from logging.handlers import TimedRotatingFileHandler
 rootPath = "/home/gantry"
 
 config = {}
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger('gantry_monitor_service')
+#logging.basicConfig(level=logging.DEBUG)
+#logger = logging.getLogger('gantry_monitor_service')
 
 # Used by the FTP log reader to track progress
 status_lastFTPLogLine = ""
@@ -851,6 +851,13 @@ if __name__ == '__main__':
         print("...no custom configuration file found. using default values")
 
     # Initialize logger handlers
+    with open("config_logging.json", 'r') as f:
+        log_config = json.load(f)
+        log_config['handlers']['file']['filename'] = config["log_path"]
+        logging.config.dictConfig(log_config)
+    logger = logging.getLogger('gantry_monitor_service')
+    
+    """
     logFmt = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
 
     trfh = TimedRotatingFileHandler(config["log_path"], when='D')
@@ -863,6 +870,7 @@ if __name__ == '__main__':
     lsh.setFormatter(logFmt)
     lsh.setLevel(logging.INFO)
     logger.addHandler(lsh)
+    """
 
     # TODO: How to handle big errors, e.g. NCSA API not responding? admin email notification?
 

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -837,6 +837,7 @@ if __name__ == '__main__':
 
     # Initialize logger handlers
     logger.addHandler(TimedRotatingFileHandler(config["log_path"], when='D'))
+    logger.addHandler(logging.StreamHandler())
 
     # TODO: How to handle big errors, e.g. NCSA API not responding? admin email notification?
 

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -523,7 +523,7 @@ def getNewFilesFromFTPLogs():
                         if fname:
                             fullname = fname.group(1).rstrip()
                             # Check if file still exists before queuing for Globus
-                            if os.path.exists(fullname):
+                            if os.path.exists(fullname.replace(config['globus']['source_path'], config['gantry']['incoming_files_path'])):
                                 fullname = fullname.replace(config['globus']['source_path'],"")
                                 foundFiles.append(fullname)
                             else:

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -848,7 +848,7 @@ if __name__ == '__main__':
         print("...no custom configuration file found. using default values")
 
     # Initialize logger handlers
-    with open("config_logging.json", 'r') as f:
+    with open(os.join(rootPath,"config_logging.json"), 'r') as f:
         log_config = json.load(f)
         log_config['handlers']['file']['filename'] = config["log_path"]
         logging.config.dictConfig(log_config)

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -563,7 +563,7 @@ def getNewFilesFromFTPLogs():
         else:
             handledBackLog = True
 
-    logger.info("- found % files from logs" % len(foundFiles))
+    logger.info("- found % files from logs" % str(len(foundFiles)))
     status_lastFTPLogLine = current_lastFTPLogLine
     return foundFiles
 

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -788,7 +788,7 @@ def globusMonitorLoop():
                                 if 'files' in task['contents'][ds]:
                                     for f in task['contents'][ds]['files']:
                                         fobj = task['contents'][ds]['files'][f]
-                                        createLocalSymlink(os.path.join(config['gantry']['incoming_files_path'], fobj['path']),
+                                        createLocalSymlink(os.path.join(config['globus']['delete_path'], fobj['path']),
                                                       os.path.join(deleteDir, fobj['path']), fobj['name'])
 
                             # Crawl and remove empty directories

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -493,7 +493,7 @@ def getNewFilesFromWatchedFolders(alreadyFound):
 def getNewFilesFromFTPLogs():
     global status_lastFTPLogLine
 
-    current_lastFTPLogLine = ""
+    current_lastFTPLogLine = status_lastFTPLogLine
     maxPending = config["gantry"]["max_pending_files"]
     foundFiles = []
 

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -370,6 +370,7 @@ def generateGlobusSubmissionID():
             return None
 
     if status_code == 200:
+        logger.debug("- generated new Globus submission ID %s" % submission_id['value'])
         return submission_id['value']
     else:
         logger.error("- could not generate new Globus submission ID (%s: %s)" % (status_code, status_message))
@@ -591,6 +592,7 @@ def initializeGlobusTransfer():
         loopingTransfers = safeCopy(pendingTransfers)
         currentTransferBatch = {}
 
+        logger.debug("- building transfer %s from pending queue" % submissionID)
         for ds in loopingTransfers:
             if "files" in loopingTransfers[ds]:
                 if ds not in currentTransferBatch:
@@ -622,6 +624,7 @@ def initializeGlobusTransfer():
         if queueLength > 0:
             # Send transfer to Globus
             try:
+                logger.debug("- attempting to send new transfer")
                 status_code, status_message, transfer_data = api.transfer(transferObj)
             except (APIError, ClientError) as e:
                 try:
@@ -827,7 +830,8 @@ def gantryMonitorLoop():
         # Check for new files in incoming gantry directory and initiate transfers if ready
         if gantryWait <= 0:
             if status_numPending < config["gantry"]["max_pending_files"]:
-                pendingTransfers.update(getGantryFilesForTransfer())
+                newPending = getGantryFilesForTransfer()
+                pendingTransfers.update(newPending)
 
                 # Clean up the pending object of straggling keys, then initialize Globus transfer
                 cleanPendingTransfers()

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -545,7 +545,8 @@ def getNewFilesFromFTPLogs():
                     foundResumePoint = True
 
                 elif foundResumePoint:
-                    current_lastFTPLogLine = line
+                    if line != "":
+                        current_lastFTPLogLine = line
 
                     # We're past the last scanned line, so capture these lines if complete & ending in 'c'
                     if re.search('ftp \d \* c', line.rstrip()):

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -29,8 +29,7 @@ from logging.handlers import TimedRotatingFileHandler
 rootPath = "/home/gantry"
 
 config = {}
-logging.basicConfig(level=logging.DEBUG,
-                    format='%(asctime)s %(levelname)-8s %(message)s')
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 # Used by the FTP log reader to track progress
@@ -836,8 +835,13 @@ if __name__ == '__main__':
         print("...no custom configuration file found. using default values")
 
     # Initialize logger handlers
-    logger.addHandler(TimedRotatingFileHandler(config["log_path"], when='D'))
-    logger.addHandler(logging.StreamHandler())
+    logFmt = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
+    trfh = TimedRotatingFileHandler(config["log_path"], when='D')
+    sh = logging.StreamHandler()
+    trfh.setFormatter(logFmt)
+    sh.setFormatter(logFmt)
+    logger.addHandler(trfh)
+    logger.addHandler(sh)
 
     # TODO: How to handle big errors, e.g. NCSA API not responding? admin email notification?
 

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -18,20 +18,17 @@
     queued for deletion.
 """
 
-import os, shutil, json, time, datetime, thread, copy, subprocess, atexit, collections, fcntl, re, gzip, logging
+import os, shutil, json, time, datetime, thread, copy, subprocess, atexit, collections, fcntl, re, gzip
+import logging, logging.config
 import requests
-import logstash
 from io import BlockingIOError
 from flask import Flask, request, Response
 from flask.ext import restful
 from globusonline.transfer.api_client import TransferAPIClient, Transfer, APIError, ClientError, goauth
-from logging.handlers import TimedRotatingFileHandler
 
 rootPath = "/home/gantry"
 
 config = {}
-#logging.basicConfig(level=logging.DEBUG)
-#logger = logging.getLogger('gantry_monitor_service')
 
 # Used by the FTP log reader to track progress
 status_lastFTPLogLine = ""
@@ -856,23 +853,6 @@ if __name__ == '__main__':
         log_config['handlers']['file']['filename'] = config["log_path"]
         logging.config.dictConfig(log_config)
     logger = logging.getLogger('gantry_monitor_service')
-    
-    """
-    logFmt = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
-
-    trfh = TimedRotatingFileHandler(config["log_path"], when='D')
-    trfh.setFormatter(logFmt)
-    trfh.setLevel(logging.DEBUG)
-    logger.addHandler(trfh)
-
-    logstash_host = "'141.142.227.152'"
-    lsh = logstash.TCPLogstashHandler(logstash_host, 5000, version=1, message_type="gantry")
-    lsh.setFormatter(logFmt)
-    lsh.setLevel(logging.INFO)
-    logger.addHandler(lsh)
-    """
-
-    # TODO: How to handle big errors, e.g. NCSA API not responding? admin email notification?
 
     # Get last read log line from previous run
     if os.path.exists(config["status_log_path"]):

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -24,6 +24,7 @@ from io import BlockingIOError
 from flask import Flask, request, Response
 from flask.ext import restful
 from globusonline.transfer.api_client import TransferAPIClient, Transfer, APIError, ClientError, goauth
+from logging.handlers import TimedRotatingFileHandler
 
 rootPath = "/home/gantry"
 
@@ -835,7 +836,7 @@ if __name__ == '__main__':
         print("...no custom configuration file found. using default values")
 
     # Initialize logger handlers
-    logger.addHandler(logging.handlers.TimedRotatingFileHandler(config["log_path"], when='D'))
+    logger.addHandler(TimedRotatingFileHandler(config["log_path"], when='D'))
 
     # TODO: How to handle big errors, e.g. NCSA API not responding? admin email notification?
 

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -712,7 +712,7 @@ def getTransferStatusFromMonitor(globusID):
         elif st.status_code == 404:
             return "NOT FOUND"
         else:
-            logger.error("%s monitor status check failed (%s: %s)" % (globusID, st.status_code, st.status_message))
+            logger.error("%s monitor status check failed (%s: %s)" % (globusID, st.status_code, st.text))
             return "UNKNOWN"
     except requests.ConnectionError as e:
         logger.error("- cannot connect to NCSA API")

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -521,8 +521,12 @@ def getNewFilesFromFTPLogs():
                         fname = re.search(fnameRegex, line)
                         if fname:
                             fullname = fname.group(1).rstrip()
-                            fullname = fullname.replace(config['globus']['source_path'],"")
-                            foundFiles.append(fullname)
+                            # Check if file still exists before queuing for Globus
+                            if os.path.exists(fullname):
+                                fullname = fullname.replace(config['globus']['source_path'],"")
+                                foundFiles.append(fullname)
+                            else:
+                                logger.info("Skipping missing file from FTP log: "+fullname)
 
                 if status_numPending+len(foundFiles) >= maxPending:
                     break

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -200,10 +200,7 @@ def createLocalSymlink(srcPath, destPath, filename):
         if not os.path.isdir(destPath):
             os.makedirs(destPath)
 
-        logger.info("- creating symlink to %s in %s" % (filename, destPath), extra={
-            "filename": filename,
-            "action": "CREATE SYMLINK"
-        })
+        logger.info("- creating symlink to %s in %s" % (filename, destPath))
         os.symlink(os.path.join(srcPath, filename),
                    os.path.join(destPath, filename))
     except OSError:

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -30,6 +30,7 @@ from logging.handlers import TimedRotatingFileHandler
 rootPath = "/home/gantry"
 
 config = {}
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('gantry_monitor_service')
 
 # Used by the FTP log reader to track progress

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -748,7 +748,7 @@ def getTransferStatusFromMonitor(globusID):
             return "UNKNOWN"
     except requests.ConnectionError as e:
         log("cannot connect to NCSA API", "ERROR")
-        return "NOT FOUND"
+        return None
 
 """Continually initiate transfers from pending queue and contact NCSA API for status updates"""
 def globusMonitorLoop():
@@ -819,6 +819,10 @@ def globusMonitorLoop():
                 # If the Globus monitor isn't even aware of this transfer, try to notify it!
                 elif globusStatus == "NOT FOUND":
                     notifyMonitorOfNewTransfer(globusID, task['contents'])
+
+                else:
+                    # Couldn't connect to NCSA API, wait for next loop to try again
+                    break
 
             status_numActive = len(activeTasks)
 

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -563,7 +563,7 @@ def getNewFilesFromFTPLogs():
         else:
             handledBackLog = True
 
-    logger.info("- found % files from logs" % str(len(foundFiles)))
+    logger.info("- found %s files from logs" % len(foundFiles))
     status_lastFTPLogLine = current_lastFTPLogLine
     return foundFiles
 

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -852,7 +852,7 @@ if __name__ == '__main__':
         log_config = json.load(f)
         log_config['handlers']['file']['filename'] = config["log_path"]
         logging.config.dictConfig(log_config)
-    logger = logging.getLogger('gantry_monitor_service')
+    logger = logging.getLogger('gantry')
 
     # Get last read log line from previous run
     if os.path.exists(config["status_log_path"]):

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -19,7 +19,7 @@
 """
 
 import os, shutil, json, time, datetime, thread, copy, subprocess, atexit, collections, fcntl, re, gzip
-import logging, logging.config
+import logging, logging.config, logstash
 import requests
 from io import BlockingIOError
 from flask import Flask, request, Response

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -837,11 +837,11 @@ if __name__ == '__main__':
     # Initialize logger handlers
     logFmt = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
     trfh = TimedRotatingFileHandler(config["log_path"], when='D')
-    sh = logging.StreamHandler()
+    #sh = logging.StreamHandler()
     trfh.setFormatter(logFmt)
-    sh.setFormatter(logFmt)
+    #sh.setFormatter(logFmt)
     logger.addHandler(trfh)
-    logger.addHandler(sh)
+    #logger.addHandler(sh)
 
     # TODO: How to handle big errors, e.g. NCSA API not responding? admin email notification?
 

--- a/scripts/gantrymonitor/gantry_monitor_service.py
+++ b/scripts/gantrymonitor/gantry_monitor_service.py
@@ -93,7 +93,6 @@ def openFileToAppend(fpath=None):
 def lockFile(f):
     # From http://tilde.town/~cristo/file-locking-in-python.html
     while True:
-        retryCount += 1
         try:
             fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
             return
@@ -559,7 +558,6 @@ def getNewFilesFromFTPLogs():
                             foundFiles.append(fullname)
 
                 if status_numPending+len(foundFiles) >= maxPending:
-                    log("maximum number of pending files reached")
                     break
 
         # If we didn't find last line in this file, look into the previous file

--- a/scripts/globusmonitor/Dockerfile
+++ b/scripts/globusmonitor/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get -y update \
     && apt-get -y install curl python python-dev python-pip \
     && pip install flask-restful \
     && pip install requests \
+    && pip install python-logstash \
     && pip install urllib3 \
     && pip install globusonline-transfer-api-client
 

--- a/scripts/globusmonitor/Dockerfile
+++ b/scripts/globusmonitor/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -y update \
 COPY globus_monitor_service.py /home/globusmonitor/globus_monitor_service.py
 COPY data /home/globusmonitor/data
 COPY config_default.json /home/globusmonitor/config_default.json
+COPY config_logging.json /home/globusmonitor/config_logging.json
 
 ENV MONITOR_API_PORT 5454
 CMD ["python", "/home/globusmonitor/globus_monitor_service.py"]

--- a/scripts/globusmonitor/config_logging.json
+++ b/scripts/globusmonitor/config_logging.json
@@ -41,6 +41,6 @@
 
   "root": {
     "level": "INFO",
-    "handlers": ["console", "logstash"]
+    "handlers": []
   }
 }

--- a/scripts/globusmonitor/config_logging.json
+++ b/scripts/globusmonitor/config_logging.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+
+  "formatters": {
+    "default": {
+      "format": "%(asctime)-15s %(levelname)-7s : %(name)s - %(message)s"
+    }
+  },
+
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "formatter": "default",
+      "level": "DEBUG",
+      "stream": "ext://sys.stdout"
+    },
+    "file": {
+      "class": "logging.handlers.RotatingFileHandler",
+      "formatter": "default",
+      "level": "INFO",
+      "filename": "ouput.log",
+      "maxBytes": 10485760,
+      "backupCount": 10,
+      "encoding": "utf8"
+    },
+    "logstash": {
+      "class": "logstash.TCPLogstashHandler",
+      "level": "INFO",
+      "host": "logger.ncsa.illinois.edu",
+      "port": 5000,
+      "message_type": "gantry",
+      "version": 1
+    }
+  },
+
+  "loggers": {
+    "gantry": {
+      "level": "DEBUG",
+      "handlers": ["console", "logstash", "file"]
+    }
+  },
+
+  "root": {
+    "level": "INFO",
+    "handlers": ["console", "logstash"]
+  }
+}

--- a/scripts/globusmonitor/config_logging.json
+++ b/scripts/globusmonitor/config_logging.json
@@ -18,9 +18,8 @@
       "class": "logging.handlers.RotatingFileHandler",
       "formatter": "default",
       "level": "DEBUG",
-      "filename": "ouput.log",
+      "filename": "globusmonitor.log",
       "maxBytes": 10485760,
-      "backupCount": 10,
       "encoding": "utf8"
     },
     "logstash": {

--- a/scripts/globusmonitor/config_logging.json
+++ b/scripts/globusmonitor/config_logging.json
@@ -17,7 +17,7 @@
     "file": {
       "class": "logging.handlers.RotatingFileHandler",
       "formatter": "default",
-      "level": "INFO",
+      "level": "DEBUG",
       "filename": "ouput.log",
       "maxBytes": 10485760,
       "backupCount": 10,

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -624,7 +624,6 @@ def notifyClowderOfCompletedTask(task):
                                 log("++ added metadata to dataset "+ds)
                                 del updatedTask['contents'][ds]['md']
                             writeCompletedTaskToDisk(updatedTask)
-                    writeCompletedTaskToDisk(updatedTask)
                 else:
                     log("dataset id for "+ds+" could not be found/created")
                     allDone = False

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -718,6 +718,7 @@ if __name__ == '__main__':
 
     # Initialize logger handlers
     logger.addHandler(TimedRotatingFileHandler(config["log_path"], when='D'))
+    logger.addHandler(logging.StreamHandler())
 
     datasetMap = loadDataFromDisk(config['dataset_map_path'])
     collectionMap = loadDataFromDisk(config['collection_map_path'])

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -18,7 +18,7 @@ from flask.ext import restful
 from flask_restful import reqparse, abort, Api, Resource
 from globusonline.transfer.api_client import TransferAPIClient, APIError, ClientError, goauth
 
-rootPath = "/projects/arpae/terraref/globus_monitor/"
+rootPath = "/home/globusmonitor/computing-pipeline/scripts/globusmonitor"
 
 """
 Config file has 2 important entries which do not have default values:

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -8,10 +8,9 @@
     succeeded or failed, and notify Clowder accordingly.
 """
 
-import os, shutil, json, time, datetime, thread, copy, atexit, collections, fcntl, logging
+import os, shutil, json, time, datetime, thread, copy, atexit, collections, fcntl
+import logging, logging.config
 import requests
-import logging.config
-import logstash
 from io import BlockingIOError
 from urllib3.filepost import encode_multipart_formdata
 from functools import wraps
@@ -19,7 +18,6 @@ from flask import Flask, request, Response
 from flask.ext import restful
 from flask_restful import reqparse, abort, Api, Resource
 from globusonline.transfer.api_client import TransferAPIClient, APIError, ClientError, goauth
-from logging.handlers import TimedRotatingFileHandler
 
 rootPath = "/home/globusmonitor/computing-pipeline/scripts/globusmonitor"
 
@@ -46,8 +44,6 @@ Config file has 2 important entries which do not have default values:
     }
 """
 config = {}
-#logging.basicConfig(level=logging.DEBUG)
-#logger = logging.getLogger('globus_monitor_service')
 
 """activeTasks tracks which Globus IDs are being monitored, and is of the format:
 {"globus_id": {
@@ -781,21 +777,6 @@ if __name__ == '__main__':
         log_config['handlers']['file']['filename'] = config["log_path"]
         logging.config.dictConfig(log_config)
     logger = logging.getLogger('globus_monitor_service')
-
-    """
-    logFmt = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
-
-    trfh = TimedRotatingFileHandler(config["log_path"], when='D')
-    trfh.setFormatter(logFmt)
-    trfh.setLevel(logging.DEBUG)
-    logger.addHandler(trfh)
-
-    logstash_host = "'141.142.227.152'"
-    lsh = logstash.TCPLogstashHandler(logstash_host, 5000, version=1, message_type="gantry")
-    lsh.setFormatter(logFmt)
-    lsh.setLevel(logging.INFO)
-    logger.addHandler(lsh)
-    """
 
     datasetMap = loadDataFromDisk(config['dataset_map_path'])
     collectionMap = loadDataFromDisk(config['collection_map_path'])

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -337,7 +337,6 @@ def fetchCollectionByName(collectionName, requestsSession):
 
 """Add dataset to Space and Sensor, Date Collections"""
 def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
-    log("space coll")
     sensorName = datasetName.split(" - ")[0]
     timestamp = datasetName.split(" - ")[1].split("__")[0]
 
@@ -358,8 +357,6 @@ def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
         sp = requestsSession.post(config['clowder']['host']+"/api/spaces/%s/addDatasetToSpace/%s" % (spid, datasetID))
         if sp.status_code != 200:
             log("cannot add ds "+datasetID+" to space "+spid+" ("+str(sp.status_code)+")")
-
-    log("space coll done")
 
 # ----------------------------------------------------------
 # API COMPONENTS
@@ -574,37 +571,29 @@ def notifyClowderOfCompletedTask(task):
 
             if len(fileFormData)>0 or datasetMD:
                 dsid = fetchDatasetByName(ds, sess)
-                log("0")
 
                 if len(fileFormData)>0:
                     # Upload collected files for this dataset
                     # Boundary encoding from http://stackoverflow.com/questions/17982741/python-using-reuests-library-for-multipart-form-data
-                    log("1")
                     (content, header) = encode_multipart_formdata(fileFormData)
                     fi = sess.post(clowderHost+"/api/uploadToDataset/"+dsid,
                                    headers={'Content-Type':header},
                                    data=content)
                     if fi.status_code != 200:
-                        log("2")
                         log("cannot upload files ("+str(fi.status_code)+" - "+fi.text+")", "ERROR")
                         return False
                     else:
-                        log("3")
                         loaded = fi.json()
                         if 'ids' in loaded:
-                            log("4")
                             for fobj in loaded['ids']:
                                 log("++ added file "+fobj['name'])
                                 updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = fobj['id']
                         else:
-                            log("5")
                             log("++ added file "+lastFile)
                             updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = loaded['id']
-                        log("6")
                         writeCompletedTaskToDisk(updatedTask)
 
                 if datasetMD:
-                    log("7")
                     # Upload metadata
                     dsmd = sess.post(clowderHost+"/api/datasets/"+dsid+"/metadata",
                                      headers={'Content-Type':'application/json'},
@@ -622,10 +611,7 @@ def notifyClowderOfCompletedTask(task):
                             log("++ added metadata to dataset "+ds)
                             del updatedTask['contents'][ds]['md']
                         writeCompletedTaskToDisk(updatedTask)
-                    log("8")
 
-                log("9")
-        log("9")
         writeCompletedTaskToDisk(updatedTask)
         return True
     else:

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -597,22 +597,25 @@ def notifyClowderOfCompletedTask(task):
 
             if len(fileFormData)>0 or datasetMD:
                 dsid = fetchDatasetByName(ds, sess)
+                logger.debug("1")
                 if dsid:
                     if len(fileFormData)>0:
                         # Upload collected files for this dataset
                         # Boundary encoding from http://stackoverflow.com/questions/17982741/python-using-reuests-library-for-multipart-form-data
+                        logger.debug("2")
                         logger.info("- uploading unprocessed files belonging to %s" % ds, extra={
                             "dataset_id": dsid,
                             "dataset_name": ds,
                             "action": "UPLOADING FILES",
                             "filelist": fileFormData
                         })
-                        
+                        logger.debug("3")
                         (content, header) = encode_multipart_formdata(fileFormData)
+                        logger.info(clowderHost+"/api/uploadToDataset/"+dsid)
                         fi = sess.post(clowderHost+"/api/uploadToDataset/"+dsid,
                                        headers={'Content-Type':header},
                                        data=content)
-
+                        logger.debug("4")
                         if fi.status_code != 200:
                             logger.error("- cannot upload files (%s - %s)" % (fi.status_code, fi.text))
                             return False

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -562,9 +562,10 @@ def notifyClowderOfCompletedTask(task):
 
             # Add local files to dataset by path
             if 'files' in task['contents'][ds]:
+                log("iterating through files belonging to "+ds)
                 for f in task['contents'][ds]['files']:
                     fobj = task['contents'][ds]['files'][f]
-                    if ('clowder_id' not in fobj or fobj['clowder_id'] == ""):
+                    if 'clowder_id' not in fobj or fobj['clowder_id'] == "":
                         if f.find("metadata.json") == -1:
                             log("adding file '"+fobj['path'])
                             # Boundary encoding from http://stackoverflow.com/questions/17982741/python-using-reuests-library-for-multipart-form-data
@@ -596,6 +597,8 @@ def notifyClowderOfCompletedTask(task):
                                 updatedTask['contents'][ds]['files'][f]['metadata_loaded'] = True
                                 updatedTask['contents'][ds]['files'][f]['clowder_id'] = "attached to dataset"
                                 writeCompletedTaskToDisk(updatedTask)
+                    else:
+                        log("skipping (already has clowder ID): "+f )
 
         writeCompletedTaskToDisk(updatedTask)
         return True

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -10,6 +10,7 @@
 
 import os, shutil, json, time, datetime, thread, copy, atexit, collections, fcntl, logging
 import requests
+import logging.config
 import logstash
 from io import BlockingIOError
 from urllib3.filepost import encode_multipart_formdata
@@ -45,8 +46,8 @@ Config file has 2 important entries which do not have default values:
     }
 """
 config = {}
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger('globus_monitor_service')
+#logging.basicConfig(level=logging.DEBUG)
+#logger = logging.getLogger('globus_monitor_service')
 
 """activeTasks tracks which Globus IDs are being monitored, and is of the format:
 {"globus_id": {
@@ -774,7 +775,14 @@ if __name__ == '__main__':
     else:
         print("...no custom configuration file found. using default values")
 
-    # Initialize logger
+    # Initialize logger handlers
+    with open("config_logging.json", 'r') as f:
+        log_config = json.load(f)
+        log_config['handlers']['file']['filename'] = config["log_path"]
+        logging.config.dictConfig(log_config)
+    logger = logging.getLogger('globus_monitor_service')
+
+    """
     logFmt = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
 
     trfh = TimedRotatingFileHandler(config["log_path"], when='D')
@@ -787,7 +795,7 @@ if __name__ == '__main__':
     lsh.setFormatter(logFmt)
     lsh.setLevel(logging.INFO)
     logger.addHandler(lsh)
-
+    """
 
     datasetMap = loadDataFromDisk(config['dataset_map_path'])
     collectionMap = loadDataFromDisk(config['collection_map_path'])

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -316,7 +316,7 @@ def fetchCollectionByName(collectionName, requestsSession):
         collid = collectionMap[collectionName]
         coll = requestsSession.get(config['clowder']['host']+"/api/collections/"+collid)
         if coll.status_code == 200:
-            #log("...collection "+collectionName+" already exists ("+collid+")")
+            log("...collection "+collectionName+" already exists ("+collid+")")
             return collid
         else:
             # Query the database just in case, before giving up and creating a new dataset
@@ -341,24 +341,30 @@ def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
     sensorName = datasetName.split(" - ")[0]
     timestamp = datasetName.split(" - ")[1].split("__")[0]
 
+    log("...adding ds "+datasetID+" to collections/spaces for "+datasetName)
     sensColl = fetchCollectionByName(sensorName, requestsSession)
     if sensColl:
         sc = requestsSession.post(config['clowder']['host']+"/api/collections/%s/datasets/%s" % (sensColl, datasetID))
         if sc.status_code != 200:
             log("could not add ds "+datasetID+" to coll "+sensColl+" ("+str(sc.status_code)+" - "+sc.text+")")
+        else:
+            log("......collection "+sensorName+" OK")
 
     timeColl = fetchCollectionByName(timestamp, requestsSession)
     if timeColl:
         tc = requestsSession.post(config['clowder']['host']+"/api/collections/%s/datasets/%s" % (timeColl, datasetID))
         if tc.status_code != 200:
             log("could not add ds "+datasetID+" to coll "+timeColl+" ("+str(tc.status_code)+" - "+tc.text+")")
+        else:
+            log("......collection "+timestamp+" OK")
 
     if config['clowder']['primary_space'] != "":
         spid = config['clowder']['primary_space']
         sp = requestsSession.post(config['clowder']['host']+"/api/spaces/%s/addDatasetToSpace/%s" % (spid, datasetID))
         if sp.status_code != 200:
             log("could not add ds "+datasetID+" to space "+spid+" ("+str(sp.status_code)+" - "+sp.text+")")
-
+        else:
+            log("......space "+spid+" OK")
 # ----------------------------------------------------------
 # API COMPONENTS
 # ----------------------------------------------------------

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -776,7 +776,7 @@ if __name__ == '__main__':
         log_config = json.load(f)
         log_config['handlers']['file']['filename'] = config["log_path"]
         logging.config.dictConfig(log_config)
-    logger = logging.getLogger('globus_monitor_service')
+    logger = logging.getLogger('gantry')
 
     datasetMap = loadDataFromDisk(config['dataset_map_path'])
     collectionMap = loadDataFromDisk(config['collection_map_path'])

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -44,8 +44,7 @@ Config file has 2 important entries which do not have default values:
     }
 """
 config = {}
-logging.basicConfig(level=logging.DEBUG,
-                    format='%(asctime)s %(levelname)-8s %(message)s')
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 """activeTasks tracks which Globus IDs are being monitored, and is of the format:
@@ -716,9 +715,14 @@ if __name__ == '__main__':
     else:
         print("...no custom configuration file found. using default values")
 
-    # Initialize logger handlers
-    logger.addHandler(TimedRotatingFileHandler(config["log_path"], when='D'))
-    logger.addHandler(logging.StreamHandler())
+    # Initialize logger
+    logFmt = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
+    trfh = TimedRotatingFileHandler(config["log_path"], when='D')
+    sh = logging.StreamHandler()
+    trfh.setFormatter(logFmt)
+    sh.setFormatter(logFmt)
+    logger.addHandler(trfh)
+    logger.addHandler(sh)
 
     datasetMap = loadDataFromDisk(config['dataset_map_path'])
     collectionMap = loadDataFromDisk(config['collection_map_path'])

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -565,36 +565,31 @@ def notifyClowderOfCompletedTask(task):
             if len(fileFormData)>0 or datasetMD:
                 logger.info("- uploading unprocessed files belonging to %s" % ds)
                 dsid = fetchDatasetByName(ds, sess)
-                logger.info("1")
+
                 if dsid:
                     if len(fileFormData)>0:
-                        logger.info("2")
                         # Upload collected files for this dataset
                         # Boundary encoding from http://stackoverflow.com/questions/17982741/python-using-reuests-library-for-multipart-form-data
                         (content, header) = encode_multipart_formdata(fileFormData)
                         fi = sess.post(clowderHost+"/api/uploadToDataset/"+dsid,
                                        headers={'Content-Type':header},
                                        data=content)
-                        logger.info("3")
+
                         if fi.status_code != 200:
                             logger.info("3fail")
                             logger.error("- cannot upload files (%s - %s)" % (fi.status_code, fi.text))
                             return False
                         else:
-                            logger.info("4")
                             loaded = fi.json()
                             if 'ids' in loaded:
                                 for fobj in loaded['ids']:
-                                    logger.info("5a")
                                     logger.info("++ added file %s" % fobj['name'])
                                     updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = fobj['id']
                                     writeCompletedTaskToDisk(updatedTask)
-                                    logger.info("5b")
                             else:
                                 logger.info("++ added file %s" % lastFile)
                                 updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = loaded['id']
                                 writeCompletedTaskToDisk(updatedTask)
-                            logger.info("6")
 
                     if datasetMD:
                         # Upload metadata

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -208,7 +208,9 @@ def loadDataFromDisk(logPath, emptyValue="{}"):
     else:
         log("...loading data from "+logPath)
 
-    return loadJsonFile(logPath)
+    d = loadJsonFile(logPath)
+    log("...load OK.")
+    return d
 
 """Save object into a log file from memory, moving existing file to .backup if it exists"""
 def writeDataToDisk(logPath, logData):
@@ -736,6 +738,7 @@ if __name__ == '__main__':
     unprocessedTasks = loadDataFromDisk(config['unprocessed_tasks_path'], '[]')
     generateAuthTokens()
 
+    log("initializing services")
     # Create thread for service to begin monitoring
     thread.start_new_thread(globusMonitorLoop, ())
     log("*** Service now monitoring Globus tasks ***")

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -718,11 +718,11 @@ if __name__ == '__main__':
     # Initialize logger
     logFmt = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
     trfh = TimedRotatingFileHandler(config["log_path"], when='D')
-    sh = logging.StreamHandler()
+    #sh = logging.StreamHandler()
     trfh.setFormatter(logFmt)
-    sh.setFormatter(logFmt)
+    #sh.setFormatter(logFmt)
     logger.addHandler(trfh)
-    logger.addHandler(sh)
+    #logger.addHandler(sh)
 
     datasetMap = loadDataFromDisk(config['dataset_map_path'])
     collectionMap = loadDataFromDisk(config['collection_map_path'])

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -586,7 +586,7 @@ def notifyClowderOfCompletedTask(task):
                             datasetMDFile = f
 
             if len(fileFormData)>0 or datasetMD:
-                log("uploading unprocessed files belonging to "+ds)
+                log("uploading unprocessed files belonging to %s" % ds)
                 dsid = fetchDatasetByName(ds, sess)
 
                 if dsid:
@@ -599,17 +599,17 @@ def notifyClowderOfCompletedTask(task):
                                        headers={'Content-Type':header},
                                        data=content)
                         if fi.status_code != 200:
-                            log("cannot upload files ("+str(fi.status_code)+" - "+fi.text+")", "ERROR")
+                            log("cannot upload files (%s - %s)" % (fi.status_code, fi.text), "ERROR")
                             return False
                         else:
                             loaded = fi.json()
                             if 'ids' in loaded:
                                 for fobj in loaded['ids']:
-                                    log("++ added file "+fobj['name'])
+                                    log("++ added file %s" % fobj['name'])
                                     updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = fobj['id']
                                     writeCompletedTaskToDisk(updatedTask)
                             else:
-                                log("++ added file "+lastFile)
+                                log("++ added file %s" % lastFile)
                                 updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = loaded['id']
                                 writeCompletedTaskToDisk(updatedTask)
 
@@ -623,21 +623,21 @@ def notifyClowderOfCompletedTask(task):
                             return False
                         else:
                             if datasetMDFile:
-                                log("++ added metadata from .json file to dataset "+ds)
+                                log("++ added metadata from .json file to dataset %s" % ds)
                                 updatedTask['contents'][ds]['files'][datasetMDFile]['metadata_loaded'] = True
                                 updatedTask['contents'][ds]['files'][datasetMDFile]['clowder_id'] = "attached to dataset"
                                 writeCompletedTaskToDisk(updatedTask)
                             else:
                                 # Remove metadata from activeTasks on success even if file upload fails in next step, so we don't repeat md
-                                log("++ added metadata to dataset "+ds)
+                                log("++ added metadata to dataset %s" % ds)
                                 del updatedTask['contents'][ds]['md']
                                 writeCompletedTaskToDisk(updatedTask)
                 else:
-                    log("dataset id for "+ds+" could not be found/created")
+                    log("dataset id for %s could not be found/created" % ds)
                     allDone = False
         return allDone
     else:
-        log("cannot find clowder user credentials for Globus user "+globUser, "ERROR")
+        log("cannot find clowder user credentials for Globus user %s" % globUser, "ERROR")
         return False
 
 """Continually check Globus API for task updates"""
@@ -720,6 +720,8 @@ def clowderSubmissionLoop():
                         log("Successfully processed task "+globusID)
                         unprocessedTasks.remove(globusID)
                         writeDataToDisk(config['unprocessed_tasks_path'], unprocessedTasks)
+                    else:
+                        log("")
                 else:
                     log("Unprocessed task "+globusID+" not found in completed tasks", "ERROR")
 

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -675,8 +675,10 @@ def clowderSubmissionLoop():
             for globusID in toHandle:
                 logPath = os.path.join(config['completed_tasks_path'], globusID[:2], globusID[2:4], globusID[4:6], globusID[6:8], globusID+".json")
                 if os.path.exists(logPath):
+                    log("Attempting to notify Clowder of completed task "+globusID)
                     clowderDone = notifyClowderOfCompletedTask(loadJsonFile(logPath))
                     if clowderDone:
+                        log("Successfully processed task "+globusID)
                         unprocessedTasks.remove(globusID)
                         writeDataToDisk(config['unprocessed_tasks_path'], unprocessedTasks)
                 else:

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -575,25 +575,32 @@ def notifyClowderOfCompletedTask(task):
                 if len(fileFormData)>0:
                     # Upload collected files for this dataset
                     # Boundary encoding from http://stackoverflow.com/questions/17982741/python-using-reuests-library-for-multipart-form-data
+                    log("1")
                     (content, header) = encode_multipart_formdata(fileFormData)
                     fi = sess.post(clowderHost+"/api/uploadToDataset/"+dsid,
                                    headers={'Content-Type':header},
                                    data=content)
                     if fi.status_code != 200:
+                        log("2")
                         log("cannot upload files ("+str(fi.status_code)+" - "+fi.text+")", "ERROR")
                         return False
                     else:
+                        log("3")
                         loaded = fi.json()
                         if 'ids' in loaded:
+                            log("4")
                             for fobj in loaded['ids']:
-                                log("++ added file '"+fobj['name'])
+                                log("++ added file "+fobj['name'])
                                 updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = fobj['id']
                         else:
-                            log("++ added file '"+lastFile)
+                            log("5")
+                            log("++ added file "+lastFile)
                             updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = loaded['id']
+                        log("6")
                         writeCompletedTaskToDisk(updatedTask)
 
                 if datasetMD:
+                    log("7")
                     # Upload metadata
                     dsmd = sess.post(clowderHost+"/api/datasets/"+dsid+"/metadata",
                                      headers={'Content-Type':'application/json'},
@@ -611,7 +618,9 @@ def notifyClowderOfCompletedTask(task):
                             log("++ added metadata to dataset "+ds)
                             del updatedTask['contents'][ds]['md']
                         writeCompletedTaskToDisk(updatedTask)
+                    log("8")
 
+        log("9")
         writeCompletedTaskToDisk(updatedTask)
         return True
     else:

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -597,7 +597,7 @@ def notifyClowderOfCompletedTask(task):
                                 datasetMD = clean_json_keys(loadJsonFile(fobj['path']))
                                 datasetMDFile = f
                         else:
-                            logger.info("%s dataset %s lists nonexistant file: %s" % (task['globus_id'], ds, fobj['path']))
+                            logger.info("%s dataset %s lists nonexistent file: %s" % (task['globus_id'], ds, fobj['path']))
                             updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = "FILE NOT FOUND"
                             writeCompletedTaskToDisk(updatedTask)
 

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -337,6 +337,7 @@ def fetchCollectionByName(collectionName, requestsSession):
 
 """Add dataset to Space and Sensor, Date Collections"""
 def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
+    log("space coll")
     sensorName = datasetName.split(" - ")[0]
     timestamp = datasetName.split(" - ")[1].split("__")[0]
 
@@ -357,6 +358,8 @@ def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
         sp = requestsSession.post(config['clowder']['host']+"/api/spaces/%s/addDatasetToSpace/%s" % (spid, datasetID))
         if sp.status_code != 200:
             log("cannot add ds "+datasetID+" to space "+spid+" ("+str(sp.status_code)+")")
+
+    log("space coll done")
 
 # ----------------------------------------------------------
 # API COMPONENTS
@@ -571,6 +574,7 @@ def notifyClowderOfCompletedTask(task):
 
             if len(fileFormData)>0 or datasetMD:
                 dsid = fetchDatasetByName(ds, sess)
+                log("0")
 
                 if len(fileFormData)>0:
                     # Upload collected files for this dataset
@@ -620,6 +624,7 @@ def notifyClowderOfCompletedTask(task):
                         writeCompletedTaskToDisk(updatedTask)
                     log("8")
 
+                log("9")
         log("9")
         writeCompletedTaskToDisk(updatedTask)
         return True

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -178,6 +178,7 @@ def getStatus():
         "active_task_count": activeTaskCount,
         "datasets_created": datasetsCreated,
         "completed_globus_tasks": completedTasks,
+        "unprocessed_task_count": len(unprocessedTasks),
         "next_unprocessed_task": unprocessedTasks[0] if len(unprocessedTasks) > 0 else ""
     }
 

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -598,7 +598,7 @@ def notifyClowderOfCompletedTask(task):
                                 datasetMDFile = f
                         else:
                             logger.info("%s dataset %s lists nonexistent file: %s" % (task['globus_id'], ds, fobj['path']))
-                            updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = "FILE NOT FOUND"
+                            updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = "FILE NOT FOUND"
                             writeCompletedTaskToDisk(updatedTask)
 
             if len(fileFormData)>0 or datasetMD:

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -254,6 +254,7 @@ def fetchDatasetByName(datasetName, requestsSession):
         ds = requestsSession.post(config['clowder']['host']+"/api/datasets/createempty",
                                   headers={"Content-Type": "application/json"},
                                   data='{"name": "%s"}' % datasetName)
+        time.sleep(1)
 
         if ds.status_code == 200:
             dsid = ds.json()['id']
@@ -297,6 +298,7 @@ def fetchCollectionByName(collectionName, requestsSession):
         coll = requestsSession.post(config['clowder']['host']+"/api/collections",
                                   headers={"Content-Type": "application/json"},
                                   data='{"name": "%s", "description": ""}' % collectionName)
+        time.sleep(1)
 
         if coll.status_code == 200:
             collid = coll.json()['id']
@@ -366,6 +368,7 @@ def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
             log("could not add ds "+datasetID+" to space "+spid+" ("+str(sp.status_code)+" - "+sp.text+")")
         else:
             log("......space "+spid+" OK")
+
 # ----------------------------------------------------------
 # API COMPONENTS
 # ----------------------------------------------------------

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -565,31 +565,35 @@ def notifyClowderOfCompletedTask(task):
             if len(fileFormData)>0 or datasetMD:
                 logger.info("- uploading unprocessed files belonging to %s" % ds)
                 dsid = fetchDatasetByName(ds, sess)
-
+                logger.info("1")
                 if dsid:
                     if len(fileFormData)>0:
-
+                        logger.info("2")
                         # Upload collected files for this dataset
                         # Boundary encoding from http://stackoverflow.com/questions/17982741/python-using-reuests-library-for-multipart-form-data
                         (content, header) = encode_multipart_formdata(fileFormData)
                         fi = sess.post(clowderHost+"/api/uploadToDataset/"+dsid,
                                        headers={'Content-Type':header},
                                        data=content)
-
+                        logger.info("3")
                         if fi.status_code != 200:
                             logger.error("- cannot upload files (%s - %s)" % (fi.status_code, fi.status_message))
                             return False
                         else:
+                            logger.info("4")
                             loaded = fi.json()
                             if 'ids' in loaded:
                                 for fobj in loaded['ids']:
+                                    logger.info("5a")
                                     logger.info("++ added file %s" % fobj['name'])
                                     updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = fobj['id']
-                                writeCompletedTaskToDisk(updatedTask)
+                                    writeCompletedTaskToDisk(updatedTask)
+                                    logger.info("5b")
                             else:
                                 logger.info("++ added file %s" % lastFile)
                                 updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = loaded['id']
                                 writeCompletedTaskToDisk(updatedTask)
+                            logger.info("6")
 
                     if datasetMD:
                         # Upload metadata

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -772,7 +772,7 @@ if __name__ == '__main__':
         print("...no custom configuration file found. using default values")
 
     # Initialize logger handlers
-    with open("config_logging.json", 'r') as f:
+    with open(os.path.join(rootPath,"config_logging.json"), 'r') as f:
         log_config = json.load(f)
         log_config['handlers']['file']['filename'] = config["log_path"]
         logging.config.dictConfig(log_config)

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -9,7 +9,7 @@
 """
 
 import os, shutil, json, time, datetime, thread, copy, atexit, collections, fcntl
-import logging, logging.config
+import logging, logging.config, logstash
 import requests
 from io import BlockingIOError
 from urllib3.filepost import encode_multipart_formdata

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -536,6 +536,7 @@ def notifyClowderOfCompletedTask(task):
         allDone = True
 
         # Prepare upload object with all file(s) found
+        updatedTask = safeCopy(task)
         for ds in task['contents']:
             fileFormData = []
             datasetMD = None
@@ -567,7 +568,6 @@ def notifyClowderOfCompletedTask(task):
                 dsid = fetchDatasetByName(ds, sess)
 
                 if dsid:
-                    updatedTask = safeCopy(task)
                     if len(fileFormData)>0:
 
                         # Upload collected files for this dataset
@@ -576,7 +576,7 @@ def notifyClowderOfCompletedTask(task):
                         fi = sess.post(clowderHost+"/api/uploadToDataset/"+dsid,
                                        headers={'Content-Type':header},
                                        data=content)
-                        # TODO: time.sleep(1) here?
+
                         if fi.status_code != 200:
                             logger.error("- cannot upload files (%s - %s)" % (fi.status_code, fi.status_message))
                             return False
@@ -586,7 +586,7 @@ def notifyClowderOfCompletedTask(task):
                                 for fobj in loaded['ids']:
                                     logger.info("++ added file %s" % fobj['name'])
                                     updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = fobj['id']
-                                    writeCompletedTaskToDisk(updatedTask)
+                                writeCompletedTaskToDisk(updatedTask)
                             else:
                                 logger.info("++ added file %s" % lastFile)
                                 updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = loaded['id']
@@ -597,7 +597,7 @@ def notifyClowderOfCompletedTask(task):
                         dsmd = sess.post(clowderHost+"/api/datasets/"+dsid+"/metadata",
                                          headers={'Content-Type':'application/json'},
                                          data=json.dumps(datasetMD))
-                        # TODO: time.sleep(1) here?
+
                         if dsmd.status_code != 200:
                             logger.error("- cannot add dataset metadata (%s: %s)" % (dsmd.status_code, dsmd.text))
                             return False

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -596,16 +596,17 @@ def notifyClowderOfCompletedTask(task):
 
             if len(fileFormData)>0 or datasetMD:
                 dsid = fetchDatasetByName(ds, sess)
-                logger.info("- uploading unprocessed files belonging to %s" % ds, extra={
-                    "dataset_id": dsid,
-                    "dataset_name": ds,
-                    "action": "UPLOADING FILES",
-                    "filelist": fileFormData
-                })
                 if dsid:
                     if len(fileFormData)>0:
                         # Upload collected files for this dataset
                         # Boundary encoding from http://stackoverflow.com/questions/17982741/python-using-reuests-library-for-multipart-form-data
+                        logger.info("- uploading unprocessed files belonging to %s" % ds, extra={
+                            "dataset_id": dsid,
+                            "dataset_name": ds,
+                            "action": "UPLOADING FILES",
+                            "filelist": fileFormData
+                        })
+                        
                         (content, header) = encode_multipart_formdata(fileFormData)
                         fi = sess.post(clowderHost+"/api/uploadToDataset/"+dsid,
                                        headers={'Content-Type':header},

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -256,7 +256,7 @@ def fetchDatasetByName(datasetName, requestsSession):
         if ds.status_code == 200:
             dsid = ds.json()['id']
             datasetMap[datasetName] = dsid
-            log("created dataset "+datasetName+" ("+dsid+")")
+            log("+ created dataset "+datasetName+" ("+dsid+")")
             writeDataToDisk(config['dataset_map_path'], datasetMap)
             addDatasetToSpacesCollections(datasetName, dsid, requestsSession)
             return dsid
@@ -269,7 +269,7 @@ def fetchDatasetByName(datasetName, requestsSession):
         dsid = datasetMap[datasetName]
         ds = requestsSession.get(config['clowder']['host']+"/api/datasets/"+dsid)
         if ds.status_code == 200:
-            log("dataset "+datasetName+" already exists ("+dsid+")")
+            log("...dataset "+datasetName+" already exists ("+dsid+")")
             return dsid
         else:
             # Query the database just in case, before giving up and creating a new dataset
@@ -299,7 +299,7 @@ def fetchCollectionByName(collectionName, requestsSession):
         if coll.status_code == 200:
             collid = coll.json()['id']
             collectionMap[collectionName] = collid
-            log("created collection "+collectionName+" ("+collid+")")
+            log("+ created collection "+collectionName+" ("+collid+")")
             writeDataToDisk(config['collection_map_path'], collectionMap)
             # Add new collection to primary space if defined
             if config['clowder']['primary_space'] != "":
@@ -315,7 +315,7 @@ def fetchCollectionByName(collectionName, requestsSession):
         collid = collectionMap[collectionName]
         coll = requestsSession.get(config['clowder']['host']+"/api/collections/"+collid)
         if coll.status_code == 200:
-            log("collection "+collectionName+" already exists ("+collid+")")
+            #log("...collection "+collectionName+" already exists ("+collid+")")
             return collid
         else:
             # Query the database just in case, before giving up and creating a new dataset
@@ -586,10 +586,10 @@ def notifyClowderOfCompletedTask(task):
                         loaded = fi.json()
                         if 'ids' in loaded:
                             for fobj in loaded['ids']:
-                                log("added file '"+fobj['name'])
+                                log("++ added file '"+fobj['name'])
                                 updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = fobj['id']
                         else:
-                            log("added file '"+lastFile)
+                            log("++ added file '"+lastFile)
                             updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = loaded['id']
                         writeCompletedTaskToDisk(updatedTask)
 
@@ -603,12 +603,12 @@ def notifyClowderOfCompletedTask(task):
                         return False
                     else:
                         if datasetMDFile:
-                            log("added metadata from .json file to dataset "+ds)
+                            log("++ added metadata from .json file to dataset "+ds)
                             updatedTask['contents'][ds]['files'][datasetMDFile]['metadata_loaded'] = True
                             updatedTask['contents'][ds]['files'][datasetMDFile]['clowder_id'] = "attached to dataset"
                         else:
                             # Remove metadata from activeTasks on success even if file upload fails in next step, so we don't repeat md
-                            log("added metadata to dataset "+ds)
+                            log("++ added metadata to dataset "+ds)
                             del updatedTask['contents'][ds]['md']
                         writeCompletedTaskToDisk(updatedTask)
 
@@ -639,7 +639,7 @@ def globusMonitorLoop():
 
                 # If this isn't done yet, leave the task active so we can try again next time
                 if globusStatus in ["SUCCEEDED", "FAILED"]:
-                    log("status update for "+globusID+": "+globusStatus)
+                    log("STATUS UPDATE FOR "+globusID+": "+globusStatus)
 
                     # Update task parameters
                     task['status'] = globusStatus

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -569,7 +569,6 @@ def notifyClowderOfCompletedTask(task):
 
             # Add local files to dataset by path
             if 'files' in task['contents'][ds]:
-                log("iterating through files belonging to "+ds)
                 for f in task['contents'][ds]['files']:
                     fobj = task['contents'][ds]['files'][f]
                     if 'clowder_id' not in fobj or fobj['clowder_id'] == "":
@@ -585,6 +584,7 @@ def notifyClowderOfCompletedTask(task):
                             datasetMDFile = f
 
             if len(fileFormData)>0 or datasetMD:
+                log("uploading unprocessed files belonging to "+ds)
                 dsid = fetchDatasetByName(ds, sess)
 
                 if dsid:
@@ -605,10 +605,11 @@ def notifyClowderOfCompletedTask(task):
                                 for fobj in loaded['ids']:
                                     log("++ added file "+fobj['name'])
                                     updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = fobj['id']
+                                    writeCompletedTaskToDisk(updatedTask)
                             else:
                                 log("++ added file "+lastFile)
                                 updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = loaded['id']
-                            writeCompletedTaskToDisk(updatedTask)
+                                writeCompletedTaskToDisk(updatedTask)
 
                     if datasetMD:
                         # Upload metadata
@@ -623,11 +624,12 @@ def notifyClowderOfCompletedTask(task):
                                 log("++ added metadata from .json file to dataset "+ds)
                                 updatedTask['contents'][ds]['files'][datasetMDFile]['metadata_loaded'] = True
                                 updatedTask['contents'][ds]['files'][datasetMDFile]['clowder_id'] = "attached to dataset"
+                                writeCompletedTaskToDisk(updatedTask)
                             else:
                                 # Remove metadata from activeTasks on success even if file upload fails in next step, so we don't repeat md
                                 log("++ added metadata to dataset "+ds)
                                 del updatedTask['contents'][ds]['md']
-                            writeCompletedTaskToDisk(updatedTask)
+                                writeCompletedTaskToDisk(updatedTask)
                 else:
                     log("dataset id for "+ds+" could not be found/created")
                     allDone = False

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -248,6 +248,9 @@ def fetchDatasetByName(datasetName, requestsSession):
     else:
         # We have a record of it, but check that it still exists before returning the ID
         dsid = datasetMap[datasetName]
+        return dsid
+
+        # TODO: re-enable this check once backlog is caught up
         ds = requestsSession.get(config['clowder']['host']+"/api/datasets/"+dsid)
         if ds.status_code == 200:
             logger.info("- dataset %s already exists (%s)" % (datasetName, dsid))
@@ -295,6 +298,9 @@ def fetchCollectionByName(collectionName, requestsSession):
     else:
         # We have a record of it, but check that it still exists before returning the ID
         collid = collectionMap[collectionName]
+        return collid
+
+        # TODO: re-enable this check once backlog is caught up
         coll = requestsSession.get(config['clowder']['host']+"/api/collections/"+collid)
         if coll.status_code == 200:
             logger.info("- collection %s already exists (%s)" % (collectionName, collid))
@@ -329,7 +335,7 @@ def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
         if sc.status_code != 200:
             logger.error("- could not add ds %s to coll %s (%s: %s)" % (datasetID, sensColl, sc.status_code, sc.text))
         else:
-            logger.info("- collection %s OK" % sensorName)
+            logger.info("- adding to collection %s OK" % sensorName)
 
     timeColl = fetchCollectionByName(timestamp, requestsSession)
     if timeColl:
@@ -337,7 +343,7 @@ def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
         if tc.status_code != 200:
             logger.error("- could not add ds %s to coll %s (%s: %s)" % (datasetID, timeColl, tc.status_code, tc.text))
         else:
-            logger.info("- collection %s OK" % timestamp)
+            logger.info("- adding to collection %s OK" % timestamp)
 
     if config['clowder']['primary_space'] != "":
         spid = config['clowder']['primary_space']
@@ -345,7 +351,7 @@ def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
         if sp.status_code != 200:
             logger.error("- could not add ds "+datasetID+" to space "+spid+" ("+str(sp.status_code)+" - "+sp.text+")")
         else:
-            logger.info("- space %s OK" % spid)
+            logger.info("- adding to space %s OK" % spid)
 
 # ----------------------------------------------------------
 # API COMPONENTS

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -598,25 +598,23 @@ def notifyClowderOfCompletedTask(task):
 
             if len(fileFormData)>0 or datasetMD:
                 dsid = fetchDatasetByName(ds, sess)
-                logger.debug("1")
                 if dsid:
                     if len(fileFormData)>0:
                         # Upload collected files for this dataset
                         # Boundary encoding from http://stackoverflow.com/questions/17982741/python-using-reuests-library-for-multipart-form-data
-                        logger.debug("2")
                         logger.info("- uploading unprocessed files belonging to %s" % ds, extra={
                             "dataset_id": dsid,
                             "dataset_name": ds,
                             "action": "UPLOADING FILES",
                             "filelist": fileFormData
                         })
-                        logger.debug("3")
+
                         (content, header) = encode_multipart_formdata(fileFormData)
                         logger.info(clowderHost+"/api/uploadToDataset/"+dsid)
                         fi = sess.post(clowderHost+"/api/uploadToDataset/"+dsid,
                                        headers={'Content-Type':header},
                                        data=content)
-                        logger.debug("4")
+
                         if fi.status_code != 200:
                             logger.error("- cannot upload files (%s - %s)" % (fi.status_code, fi.text))
                             return False

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -595,14 +595,13 @@ def notifyClowderOfCompletedTask(task):
                             datasetMDFile = f
 
             if len(fileFormData)>0 or datasetMD:
+                dsid = fetchDatasetByName(ds, sess)
                 logger.info("- uploading unprocessed files belonging to %s" % ds, extra={
                     "dataset_id": dsid,
                     "dataset_name": ds,
                     "action": "UPLOADING FILES",
                     "filelist": fileFormData
                 })
-                dsid = fetchDatasetByName(ds, sess)
-
                 if dsid:
                     if len(fileFormData)>0:
                         # Upload collected files for this dataset

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -242,7 +242,7 @@ def fetchDatasetByName(datasetName, requestsSession):
             addDatasetToSpacesCollections(datasetName, dsid, requestsSession)
             return dsid
         else:
-            logger.error("- cannot create dataset (%s: %s)" % (ds.status_code, ds.status_message))
+            logger.error("- cannot create dataset (%s: %s)" % (ds.status_code, ds.text))
             return None
 
     else:
@@ -289,7 +289,7 @@ def fetchCollectionByName(collectionName, requestsSession):
                                      (config['clowder']['primary_space'], collid))
             return collid
         else:
-            logger.error("- cannot create collection (%s: %s)" % (coll.status_code, coll.status_message))
+            logger.error("- cannot create collection (%s: %s)" % (coll.status_code, coll.text))
             return None
 
     else:
@@ -327,7 +327,7 @@ def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
     if sensColl:
         sc = requestsSession.post(config['clowder']['host']+"/api/collections/%s/datasets/%s" % (sensColl, datasetID))
         if sc.status_code != 200:
-            logger.error("- could not add ds %s to coll %s (%s: %s)" % (datasetID, sensColl, sc.status_code, sc.status_message))
+            logger.error("- could not add ds %s to coll %s (%s: %s)" % (datasetID, sensColl, sc.status_code, sc.text))
         else:
             logger.info("- collection %s OK" % sensorName)
 
@@ -335,7 +335,7 @@ def addDatasetToSpacesCollections(datasetName, datasetID, requestsSession):
     if timeColl:
         tc = requestsSession.post(config['clowder']['host']+"/api/collections/%s/datasets/%s" % (timeColl, datasetID))
         if tc.status_code != 200:
-            logger.error("- could not add ds %s to coll %s (%s: %s)" % (datasetID, timeColl, tc.status_code, tc.status_message))
+            logger.error("- could not add ds %s to coll %s (%s: %s)" % (datasetID, timeColl, tc.status_code, tc.text))
         else:
             logger.info("- collection %s OK" % timestamp)
 
@@ -577,7 +577,8 @@ def notifyClowderOfCompletedTask(task):
                                        data=content)
                         logger.info("3")
                         if fi.status_code != 200:
-                            logger.error("- cannot upload files (%s - %s)" % (fi.status_code, fi.status_message))
+                            logger.info("3fail")
+                            logger.error("- cannot upload files (%s - %s)" % (fi.status_code, fi.text))
                             return False
                         else:
                             logger.info("4")

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -693,7 +693,7 @@ def globusMonitorLoop():
 def clowderSubmissionLoop():
     global unprocessedTasks
 
-    clowderWait = 0
+    clowderWait = config['clowder']['globus_processing_frequency'] - 1
     while True:
         time.sleep(1)
         clowderWait += 1

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -615,7 +615,6 @@ def notifyClowderOfCompletedTask(task):
                         })
 
                         (content, header) = encode_multipart_formdata(fileFormData)
-                        logger.info(clowderHost+"/api/uploadToDataset/"+dsid)
                         fi = sess.post(clowderHost+"/api/uploadToDataset/"+dsid,
                                        headers={'Content-Type':header},
                                        data=content)
@@ -627,19 +626,11 @@ def notifyClowderOfCompletedTask(task):
                             loaded = fi.json()
                             if 'ids' in loaded:
                                 for fobj in loaded['ids']:
-                                    logger.info("++ added file %s" % fobj['name'], extra={
-                                        "file_id": fobj['id'],
-                                        "filename": fobj['name'],
-                                        "action": "FILE ADDED"
-                                    })
+                                    logger.info("++ added file %s" % fobj['name'])
                                     updatedTask['contents'][ds]['files'][fobj['name']]['clowder_id'] = fobj['id']
                                     writeCompletedTaskToDisk(updatedTask)
                             else:
-                                logger.info("++ added file %s" % lastFile, extra={
-                                    "file_id": loaded['id'],
-                                    "filename": lastFile,
-                                    "action": "FILE ADDED"
-                                })
+                                logger.info("++ added file %s" % lastFile)
                                 updatedTask['contents'][ds]['files'][lastFile]['clowder_id'] = loaded['id']
                                 writeCompletedTaskToDisk(updatedTask)
 

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -45,6 +45,7 @@ Config file has 2 important entries which do not have default values:
     }
 """
 config = {}
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('globus_monitor_service')
 
 """activeTasks tracks which Globus IDs are being monitored, and is of the format:

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -653,6 +653,7 @@ def globusMonitorLoop():
 
         # Check with Globus for any status updates on monitored tasks
         if globWait >= config['globus']['transfer_update_frequency_secs']:
+            log("Checking for Globus updates")
             # Use copy of task list so it doesn't change during iteration
             currentActiveTasks = safeCopy(activeTasks)
             for globusID in currentActiveTasks:
@@ -707,6 +708,7 @@ def clowderSubmissionLoop():
 
         # Check with Globus for any status updates on monitored tasks
         if clowderWait >= config['clowder']['globus_processing_frequency']:
+            log("Checking unprocessed tasks")
             toHandle = safeCopy(unprocessedTasks)
 
             for globusID in toHandle:

--- a/scripts/globusmonitor/globus_monitor_service.py
+++ b/scripts/globusmonitor/globus_monitor_service.py
@@ -592,6 +592,7 @@ def notifyClowderOfCompletedTask(task):
                 if dsid:
                     updatedTask = safeCopy(task)
                     if len(fileFormData)>0:
+
                         # Upload collected files for this dataset
                         # Boundary encoding from http://stackoverflow.com/questions/17982741/python-using-reuests-library-for-multipart-form-data
                         (content, header) = encode_multipart_formdata(fileFormData)


### PR DESCRIPTION
As discussed in #79, there are 2 components in /scripts/globusmonitor:

**gantry_monitor_service.py**
This has a service component which will monitor a directory for files that are more than 15 mins old (or whatever config time is). It will add those files to a PendingTransfers queue, organized by dataset (dataset = "sensorName timestamp"). There is also a lightweight API component that allows someone on that network to manually submit files to the PendingTransfers queue - MAC script can do this to avoid waiting for the 15-min crawler to catch the file.

Every X minutes a Globus transfer is started with everything in PendingTransfers, and a message is sent to the globus_monitor_service API on the NCSA side with the Globus task ID. The task is added to a log listing time, component files, etc.

Every Y minutes the NCSA API is queried about the tasks in this log. When that API reports the task as complete and the file was successfully processed into the Clowder pipeline, the gantry-side original files are moved to a folder where they can be queued for deletion. 

**globus_monitor_service.py**
This has a service component that will query Globus every N minutes regarding the transfer status of the globus tasks it is monitoring. There is also an API component that accepts new tasks to monitor, as well as GET task details and remove tasks from monitoring.

When the API receives a new task (typically from the gantry_monitor_service), it will continually check the status of the transfer until it is either SUCCEEDED or FAILED. On success, this service will submit all files included in that task to Clowder for processing, creating the dataset if necessary, and writing to a log file. It maintains a map of datasetName -> clowderDatasetUUID, so when a dataset named "sensorName timestampXYZ" is created, any other files that arrive with that same dataset name will go in the same Clowder dataset. The file is submitted to clowder using a local file path, so the file is not moved out of the Globus landing directory even when processed.

**notes**
Both files have a companion config file. Generally you can specify IP and port numbers, globus user credentials and endpoint IDs (I determined them from [here](https://www.globus.org/app/endpoints)), various wait times between checks, and where to write log files/globus transfers.

**todos/questions**
- **I think we should have admin emails that can be listed in the config file**, who get an email if certain errors are encountered (e.g. gantry can't contact globus, NCSA API not responding, etc)
- want to dockerize both of these - both have some python dependencies (like requests) that need to be available in the environment
- Need some help thinking through **how best to simulate whole pipeline**. I have access to Roger and CampusCluster now, but not sure best practice for running the scripts there (installing python libs) or via docker. generally, i planned to create a /gantry folder on my Roger space and run the gantry monitor, then run the globus monitor on my laptop, and move files to the Roger /gantry folder so they're passed along to globus. 
- There's **still hardening to be done** - once this goes, it's meant to go 24/7 more or less. The pending/active/completed tasks and the dataset->UUID map are continually written to log files when updated with a single backup, so data should generally be recoverable on a crash. However most of the try/catch blocks for errors are fairly simple and I don't do a whole lot when API requests return 400s/404s beyond printing something out to the console (which **should really be a separate log file itself** now that I think about it).

But I thought I'd go ahead and make this pull request now to get some of these thoughts out there.