### PR TITLE
Globus pipeline improvements

### DIFF
--- a/scripts/gantrymonitor/config_logging.json
+++ b/scripts/gantrymonitor/config_logging.json
@@ -35,12 +35,12 @@
   "loggers": {
     "gantry": {
       "level": "DEBUG",
-      "handlers": ["console", "logstash", "file"]
+      "handlers": ["file"]
     }
   },
 
   "root": {
     "level": "INFO",
-    "handlers": []
+    "handlers": ["console", "logstash"]
   }
 }

--- a/scripts/gantrymonitor/config_logging.json
+++ b/scripts/gantrymonitor/config_logging.json
@@ -15,11 +15,11 @@
       "stream": "ext://sys.stdout"
     },
     "file": {
-      "class": "logging.handlers.RotatingFileHandler",
+      "class": "logging.handlers.TimedRotatingFileHandler",
       "formatter": "default",
       "level": "DEBUG",
       "filename": "gantry.log",
-      "maxBytes": 10485760,
+      "when": "D",
       "encoding": "utf8"
     },
     "logstash": {

--- a/scripts/globusmonitor/config_logging.json
+++ b/scripts/globusmonitor/config_logging.json
@@ -15,11 +15,11 @@
       "stream": "ext://sys.stdout"
     },
     "file": {
-      "class": "logging.handlers.RotatingFileHandler",
+      "class": "logging.handlers.TimedRotatingFileHandler",
       "formatter": "default",
       "level": "DEBUG",
       "filename": "globusmonitor.log",
-      "maxBytes": 10485760,
+      "when": "D",
       "encoding": "utf8"
     },
     "logstash": {

--- a/scripts/globusmonitor/config_logging.json
+++ b/scripts/globusmonitor/config_logging.json
@@ -35,12 +35,12 @@
   "loggers": {
     "gantry": {
       "level": "DEBUG",
-      "handlers": ["console", "logstash", "file"]
+      "handlers": ["file"]
     }
   },
 
   "root": {
     "level": "INFO",
-    "handlers": []
+    "handlers": ["console", "logstash"]
   }
 }


### PR DESCRIPTION
This changes the loggers on the gantry and ROGER to rotate once per day (as opposed to by file size) and adjusts which messages are sent to which loggers (logstash, console, file).