### PR TITLE
Adding netcdf metadata to the hyperspectral extractor

### DIFF
--- a/scripts/hyperspectral/extractor/terra.hyperspectral.py
+++ b/scripts/hyperspectral/extractor/terra.hyperspectral.py
@@ -90,6 +90,19 @@ def process_dataset(parameters):
 			print 'uploading output file...'
 			extractors.upload_file_to_dataset(filepath=outFilePath, parameters=parameters)
 			print 'done uploading'
+			print 'extracting metadata in cdl format'
+			metaFilePath = outFilePath + '.cdl'
+			with open(metaFilePath, 'w') as fmeta:
+				subprocess.call('nkcs', '--cdl', '-m', '-M', outFilePath], stdout=fmeta)
+			if os.path.exists(metaFilePath):
+				extractors.upload_file_to_dataset(filepath=metaFilePath, parameters=parameters)
+
+			print 'extracting metadata in xml format'
+			metaFilePath = outFilePath + '.xml'
+			with open(metaFilePath, 'w') as fmeta:
+				subprocess.call('nkcs', '--xml', '-m', '-M', outFilePath], stdout=fmeta)
+			if os.path.exists(metaFilePath):
+				extractors.upload_file_to_dataset(filepath=metaFilePath, parameters=parameters)
 		# Clean up the output file.
 		os.remove(outFilePath)
 	else:

--- a/scripts/hyperspectral/extractor/terra.hyperspectral.py
+++ b/scripts/hyperspectral/extractor/terra.hyperspectral.py
@@ -93,14 +93,14 @@ def process_dataset(parameters):
 			print 'extracting metadata in cdl format'
 			metaFilePath = outFilePath + '.cdl'
 			with open(metaFilePath, 'w') as fmeta:
-				subprocess.call('nkcs', '--cdl', '-m', '-M', outFilePath], stdout=fmeta)
+				subprocess.call('ncks', '--cdl', '-m', '-M', outFilePath], stdout=fmeta)
 			if os.path.exists(metaFilePath):
 				extractors.upload_file_to_dataset(filepath=metaFilePath, parameters=parameters)
 
 			print 'extracting metadata in xml format'
 			metaFilePath = outFilePath + '.xml'
 			with open(metaFilePath, 'w') as fmeta:
-				subprocess.call('nkcs', '--xml', '-m', '-M', outFilePath], stdout=fmeta)
+				subprocess.call('ncks', '--xml', '-m', '-M', outFilePath], stdout=fmeta)
 			if os.path.exists(metaFilePath):
 				extractors.upload_file_to_dataset(filepath=metaFilePath, parameters=parameters)
 		# Clean up the output file.


### PR DESCRIPTION
This is to address #145 .

The output is supposed to be json. But two attempts failed using xml2json and ncdump-json respectively. See issue discussion.

So for now, I output xml and cdl metadata files using `ncks --xml -m -M` and `ncks --cdl -m -M` respectively, until a good solution is found to generate json output.