### PR TITLE
pass args to query as args for execute()

### DIFF
--- a/scripts/globusmonitor/globus_uploader_service.py
+++ b/scripts/globusmonitor/globus_uploader_service.py
@@ -139,7 +139,7 @@ def connectToPostgres():
         conn = psycopg2.connect(dbname='postgres', host=psql_host)
         conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         curs = conn.cursor()
-        curs.execute('CREATE DATABASE %s;' % psql_db)
+        curs.execute('CREATE DATABASE %s;', (psql_db))
         curs.close()
         conn.commit()
         conn.close()
@@ -188,14 +188,13 @@ def writeTaskToDatabase(task):
 
     # Attempt to insert, update if globus ID already exists
     q_insert = "INSERT INTO globus_tasks (globus_id, status, received, completed, globus_user, contents) " \
-               "VALUES ('%s', '%s', '%s', '%s', '%s', '%s') " \
+               "VALUES (%s, %s, %s, %s, %s, %s) " \
                "ON CONFLICT (globus_id) DO UPDATE " \
-               "SET status='%s', received='%s', completed='%s', globus_user='%s', contents='%s';" % (
-                   gid, stat, recv, comp, guser, jbody, stat, recv, comp, guser, jbody)
+               "SET status=%s, received=%s, completed=%s, globus_user=%s, contents=%s;"
 
     curs = psql_conn.cursor()
     #logger.debug("Writing task %s to PostgreSQL..." % gid)
-    curs.execute(q_insert)
+    curs.execute(q_insert, (gid, stat, recv, comp, guser, jbody, stat, recv, comp, guser, jbody))
     psql_conn.commit()
     curs.close()
 
@@ -204,17 +203,17 @@ def getNextUnprocessedTask(status="SUCCEEDED", reverse=False):
 
     # Use Common Table Expression to update status to PENDING and return row at the same time
     if reverse:
-        q_fetch = "WITH cte AS (SELECT globus_id FROM globus_tasks where STATUS = '%s' ORDER BY completed DESC LIMIT 1 FOR UPDATE SKIP LOCKED) UPDATE globus_tasks gt  SET status = 'PENDING' FROM cte WHERE gt.globus_id = cte.globus_id RETURNING *" %status
+        q_fetch = "WITH cte AS (SELECT globus_id FROM globus_tasks where STATUS = %s ORDER BY completed DESC LIMIT 1 FOR UPDATE SKIP LOCKED) UPDATE globus_tasks gt  SET status = 'PENDING' FROM cte WHERE gt.globus_id = cte.globus_id RETURNING *"
 
     else:
-        q_fetch = "WITH cte AS (SELECT globus_id FROM globus_tasks where STATUS = '%s' ORDER BY completed ASC LIMIT 1 FOR UPDATE SKIP LOCKED) UPDATE globus_tasks gt  SET status = 'PENDING' FROM cte WHERE gt.globus_id = cte.globus_id RETURNING *" %status
+        q_fetch = "WITH cte AS (SELECT globus_id FROM globus_tasks where STATUS = %s ORDER BY completed ASC LIMIT 1 FOR UPDATE SKIP LOCKED) UPDATE globus_tasks gt  SET status = 'PENDING' FROM cte WHERE gt.globus_id = cte.globus_id RETURNING *"
 
     nextTask = None
 
     try:
         curs = psql_conn.cursor()
         logger.debug("Fetching next %s task from PostgreSQL..." % status)
-        curs.execute(q_fetch)
+        curs.execute(q_fetch, (status))
         for result in curs:
             nextTask = {
                 "globus_id": result[0],
@@ -237,39 +236,13 @@ def getNextUnprocessedTask(status="SUCCEEDED", reverse=False):
         logger.debug("No task found.")
     return nextTask
 
-"""Write dataset (name -> clowder_id) mapping to PostgreSQL database"""
-def writeDatasetRecordToDatabase(dataset_name, dataset_id):
-
-    q_insert = "INSERT INTO datasets (name, clowder_id) VALUES ('%s', '%s') " \
-               "ON CONFLICT (name) DO UPDATE SET clowder_id='%s';" % (
-                   dataset_name, dataset_id, dataset_id)
-
-    curs = psql_conn.cursor()
-    #logger.debug("Writing dataset %s to PostgreSQL..." % dataset_name)
-    curs.execute(q_insert)
-    psql_conn.commit()
-    curs.close()
-
-"""Write collection (name -> clowder_id) mapping to PostgreSQL database"""
-def writeCollectionRecordToDatabase(collection_name, collection_id):
-
-    q_insert = "INSERT INTO collections (name, clowder_id) VALUES ('%s', '%s') " \
-               "ON CONFLICT (name) DO UPDATE SET clowder_id='%s';" % (
-                   collection_name, collection_id, collection_id)
-
-    curs = psql_conn.cursor()
-    #logger.debug("Writing collection %s to PostgreSQL..." % collection_name)
-    curs.execute(q_insert)
-    psql_conn.commit()
-    curs.close()
-
 """Remove PENDING status from any ongoing processing if this is killed"""
 def gracefulExit(signum, frame):
     if current_task:
         curs = psql_conn.cursor()
-        query = "update globus_tasks set STATUS='SUCCEEDED' where globus_id = '%s';" % current_task
+        query = "update globus_tasks set STATUS='SUCCEEDED' where globus_id = %s;"
         logger.debug("Gracefully resolving PENDING for %s" % current_task)
-        curs.execute(query)
+        curs.execute(query, (current_task))
         psql_conn.commit()
         curs.close()
 


### PR DESCRIPTION
avoid escape errors when inserting error codes into db with apostrophes.