### PR TITLE
Catch globus 404s and more informative logging

### DIFF
--- a/scripts/gantrymonitor/globus_manager_service.py
+++ b/scripts/gantrymonitor/globus_manager_service.py
@@ -506,7 +506,7 @@ def globusMonitorLoop():
                         try:
                             writeTaskToPostgres(task)
                             writeTaskToInflux(task)
-                        except:
+                        except Exception as e:
                             logger.debug("- error writing task: %s" % e)
                             logger.debug("- skipping remaining CREATED tasks this iteration")
                             break

--- a/scripts/gantrymonitor/globus_manager_service.py
+++ b/scripts/gantrymonitor/globus_manager_service.py
@@ -514,7 +514,6 @@ def globusMonitorLoop():
                         task['status'] = task_data['status']
                         try:
                             writeTaskToPostgres(task)
-                            writeTaskToInflux(task)
                         except Exception as e:
                             logger.debug("- error writing task: %s" % e)
                             logger.debug("- skipping remaining CREATED tasks this iteration")
@@ -545,7 +544,6 @@ def globusMonitorLoop():
                         task['status'] = task_data['status']
                         try:
                             writeTaskToPostgres(task)
-                            writeTaskToInflux(task)
                         except Exception as e:
                             logger.debug("- error writing task: %s" % e)
                             logger.debug("- skipping remaining IN PROGRESS tasks this iteration")

--- a/scripts/gantrymonitor/globus_manager_service.py
+++ b/scripts/gantrymonitor/globus_manager_service.py
@@ -102,7 +102,7 @@ def getGlobusTaskData(task):
         logger.error("%s gaierror checking with Globus for transfer status: %s" % (task['globus_id'], e))
         status_code = 404
     except Exception as e:
-        if e.status_code == 404:
+        if hasattr(e, 'status_code') and e.status_code == 404:
             return {"status": "NOT FOUND"}
         try:
             # Refreshing auth tokens and retry
@@ -114,7 +114,7 @@ def getGlobusTaskData(task):
             logger.error("%s gaierror checking with Globus for transfer status: %s" % (task['globus_id'], e))
             status_code = 404
         except Exception as e:
-            if e.status_code == 404:
+            if hasattr(e, 'status_code') and e.status_code == 404:
                 return {"status": "NOT FOUND"}
 
             logger.error("%s error checking with Globus for transfer status" % task['globus_id'])


### PR DESCRIPTION
- if a globus task ID returns 404, mark it as not found in db and stop rechecking.
- if influxDB system is down, skip remaining tasks for this iteration.